### PR TITLE
Add package level logging functions with DefaultLogger variable

### DIFF
--- a/default_logger.go
+++ b/default_logger.go
@@ -1,0 +1,59 @@
+package slog
+
+import (
+	"context"
+	"os"
+)
+
+// DefaultLogger is a default logger and is used by package level logging functions Debug, Info, Warn, Err, Critical and Fatal
+// DefaultLogger does not have any sinks by default
+var DefaultLogger Logger = Logger{
+	sinks: make([]Sink, 0),
+	level: LevelDebug,
+	exit:  os.Exit,
+}
+
+// Debug logs the msg and fields at LevelDebug with DefaultLogger.
+func Debug(ctx context.Context, msg string, fields ...Field) {
+	DefaultLogger.log(ctx, LevelDebug, msg, fields)
+}
+
+// Info logs the msg and fields at LevelInfo with DefaultLogger.
+func Info(ctx context.Context, msg string, fields ...Field) {
+	DefaultLogger.log(ctx, LevelInfo, msg, fields)
+}
+
+// Warn logs the msg and fields at LevelWarn with DefaultLogger.
+func Warn(ctx context.Context, msg string, fields ...Field) {
+	DefaultLogger.log(ctx, LevelWarn, msg, fields)
+}
+
+// Err logs the msg and fields at LevelError with DefaultLogger.
+//
+// It will then Sync().
+func Err(ctx context.Context, msg string, fields ...Field) {
+	DefaultLogger.log(ctx, LevelError, msg, fields)
+	DefaultLogger.Sync()
+}
+
+// Critical logs the msg and fields at LevelCritical with DefaultLogger.
+//
+// It will then Sync().
+func Critical(ctx context.Context, msg string, fields ...Field) {
+	DefaultLogger.log(ctx, LevelCritical, msg, fields)
+	DefaultLogger.Sync()
+}
+
+// Fatal logs the msg and fields at LevelFatal with DefaultLogger.
+//
+// It will then Sync() and os.Exit(1).
+func Fatal(ctx context.Context, msg string, fields ...Field) {
+	DefaultLogger.log(ctx, LevelFatal, msg, fields)
+	DefaultLogger.Sync()
+
+	if DefaultLogger.exit == nil {
+		DefaultLogger.exit = defaultExitFn
+	}
+
+	DefaultLogger.exit(1)
+}


### PR DESCRIPTION
Enables easy usage of a shared logger instance across different go packages.

DefaultLogger can be initialized in e.g. main package and `slog.Info` can be used anywhere in the system.
```
slog.DefaultLogger = slog.Make(sloghuman.Sink(os.Stdout))
slog.Info(ctx, "hello")
```

Loosely related to issue #82 

There are two things that I'm not fully happy with:
1. The `slog.Error` function is already in use so `DefaultLogger.Error()` is published as `slog.Err()`. Changing this would break the API
2. Initialization of `DefaultLogger` is needed to have any output. There is no default sink created (as discussed in linked issue it would be a circular reference)