### PR TITLE
feat: Use human timestamp to display date

### DIFF
--- a/example_helper_test.go
+++ b/example_helper_test.go
@@ -23,5 +23,5 @@ func ExampleHelper() {
 	ctx := context.Background()
 	httpLogHelper(ctx, http.StatusBadGateway)
 
-	// 2019-12-07 21:18:42.567 [INFO]	<example_helper_test.go:24>	sending HTTP response	{"status": 502}
+	// Dec  7 21:18:42.567 [INFO]	<example_helper_test.go:24>	sending HTTP response	{"status": 502}
 }

--- a/example_marshaller_test.go
+++ b/example_marshaller_test.go
@@ -30,5 +30,5 @@ func Example_marshaller() {
 		}),
 	)
 
-	// 2019-12-16 17:31:37.120 [INFO]	<example_marshaller_test.go:26>	wow	{"myStruct": {"foo": 1, "bar": 1}}
+	// Dec 16 17:31:37.120 [INFO]	<example_marshaller_test.go:26>	wow	{"myStruct": {"foo": 1, "bar": 1}}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -34,7 +34,7 @@ func Example() {
 		),
 	)
 
-	// 2019-12-09 05:04:53.398 [INFO]	<example.go:16>	my message here	{"field_name": "something or the other", "some_map": {"nested_fields": "2000-02-05T04:04:04Z"}} ...
+	// Dec  9 05:04:53.398 [INFO]	<example.go:16>	my message here	{"field_name": "something or the other", "some_map": {"nested_fields": "2000-02-05T04:04:04Z"}} ...
 	//  "error": wrap1:
 	//      main.main
 	//          /Users/nhooyr/src/cdr/scratch/example.go:22
@@ -61,7 +61,7 @@ func Example_struct() {
 		}),
 	)
 
-	// 2019-12-16 17:31:51.769 [INFO]	<example_test.go:56>	check out my structure	{"hello": {"meow": 1, "bar": "barbar", "m": "2000-02-05T04:04:04Z"}}
+	// Dec 16 17:31:51.769 [INFO]	<example_test.go:56>	check out my structure	{"hello": {"meow": 1, "bar": "barbar", "m": "2000-02-05T04:04:04Z"}}
 }
 
 func Example_testing() {
@@ -72,7 +72,7 @@ func Example_testing() {
 		slog.F("field_name", "something or the other"),
 	)
 
-	// t.go:55: 2019-12-05 21:20:31.218 [INFO]	<examples_test.go:42>	my message here	{"field_name": "something or the other"}
+	// t.go:55: Dec  5 21:20:31.218 [INFO]	<examples_test.go:42>	my message here	{"field_name": "something or the other"}
 }
 
 func Example_tracing() {
@@ -82,7 +82,7 @@ func Example_tracing() {
 
 	log.Info(ctx, "my msg", slog.F("hello", "hi"))
 
-	// 2019-12-09 21:59:48.110 [INFO]	<example_test.go:62>	my msg	{"trace": "f143d018d00de835688453d8dc55c9fd", "span": "f214167bf550afc3", "hello": "hi"}
+	// Dec  9 21:59:48.110 [INFO]	<example_test.go:62>	my msg	{"trace": "f143d018d00de835688453d8dc55c9fd", "span": "f214167bf550afc3", "hello": "hi"}
 }
 
 func Example_multiple() {
@@ -97,7 +97,7 @@ func Example_multiple() {
 
 	l.Info(context.Background(), "log to stdout and stackdriver")
 
-	// 2019-12-07 20:59:55.790 [INFO]	<example_test.go:46>	log to stdout and stackdriver
+	// Dec  7 20:59:55.790 [INFO]	<example_test.go:46>	log to stdout and stackdriver
 }
 
 func ExampleWith() {
@@ -106,7 +106,7 @@ func ExampleWith() {
 	l := slog.Make(sloghuman.Sink(os.Stdout))
 	l.Info(ctx, "msg")
 
-	// 2019-12-07 20:54:23.986 [INFO]	<example_test.go:20>	msg	{"field": 1}
+	// Dec  7 20:54:23.986 [INFO]	<example_test.go:20>	msg	{"field": 1}
 }
 
 func ExampleStdlib() {
@@ -115,7 +115,7 @@ func ExampleStdlib() {
 
 	l.Print("msg")
 
-	// 2019-12-07 20:54:23.986 [INFO]	(stdlib)	<example_test.go:29>	msg	{"field": 1}
+	// Dec  7 20:54:23.986 [INFO]	(stdlib)	<example_test.go:29>	msg	{"field": 1}
 }
 
 func ExampleLogger_Named() {
@@ -125,7 +125,7 @@ func ExampleLogger_Named() {
 	l = l.Named("http")
 	l.Info(ctx, "received request", slog.F("remote address", net.IPv4(127, 0, 0, 1)))
 
-	// 2019-12-07 21:20:56.974 [INFO]	(http)	<example_test.go:85>	received request	{"remote address": "127.0.0.1"}
+	// Dec  7 21:20:56.974 [INFO]	(http)	<example_test.go:85>	received request	{"remote address": "127.0.0.1"}
 }
 
 func ExampleLogger_Leveled() {
@@ -139,6 +139,6 @@ func ExampleLogger_Leveled() {
 
 	l.Debug(ctx, "testing2")
 
-	// 2019-12-07 21:26:20.945 [INFO]	<example_test.go:95>	received request
-	// 2019-12-07 21:26:20.945 [DEBUG]	<example_test.go:99>	testing2
+	// Dec  7 21:26:20.945 [INFO]	<example_test.go:95>	received request
+	// Dec  7 21:26:20.945 [DEBUG]	<example_test.go:99>	testing2
 }

--- a/internal/entryhuman/entry.go
+++ b/internal/entryhuman/entry.go
@@ -31,8 +31,8 @@ func StripTimestamp(ent string) (time.Time, string, error) {
 	return et, rest, err
 }
 
-// TimeFormat is a simplified RFC3339 format.
-const TimeFormat = "2006-01-02 15:04:05.000"
+// TimeFormat references the StampMilli format.
+const TimeFormat = time.StampMilli
 
 func c(w io.Writer, attrs ...color.Attribute) *color.Color {
 	c := color.New(attrs...)

--- a/internal/entryhuman/entry_test.go
+++ b/internal/entryhuman/entry_test.go
@@ -33,7 +33,7 @@ func TestEntry(t *testing.T) {
 			File: "myfile",
 			Line: 100,
 			Func: "mypkg.ignored",
-		}, `2000-02-05 04:04:04.000 [DEBUG]	<mypkg/myfile:100>	ignored	"wowowow\tizi"`)
+		}, `Feb  5 04:04:04.000 [DEBUG]	<mypkg/myfile:100>	ignored	"wowowow\tizi"`)
 	})
 
 	t.Run("multilineMessage", func(t *testing.T) {
@@ -42,7 +42,7 @@ func TestEntry(t *testing.T) {
 		test(t, slog.SinkEntry{
 			Message: "line1\nline2",
 			Level:   slog.LevelInfo,
-		}, `0001-01-01 00:00:00.000 [INFO]	<.:0>		...
+		}, `Jan  1 00:00:00.000 [INFO]	<.:0>		...
 "msg": line1
        line2`)
 	})
@@ -54,7 +54,7 @@ func TestEntry(t *testing.T) {
 			Message: "msg",
 			Level:   slog.LevelInfo,
 			Fields:  slog.M(slog.F("field", "line1\nline2")),
-		}, `0001-01-01 00:00:00.000 [INFO]	<.:0>		msg ...
+		}, `Jan  1 00:00:00.000 [INFO]	<.:0>		msg ...
 "field": line1
          line2`)
 	})
@@ -65,7 +65,7 @@ func TestEntry(t *testing.T) {
 		test(t, slog.SinkEntry{
 			Level:       slog.LevelWarn,
 			LoggerNames: []string{"named", "meow"},
-		}, `0001-01-01 00:00:00.000 [WARN]	(named.meow)	<.:0>		""`)
+		}, `Jan  1 00:00:00.000 [WARN]	(named.meow)	<.:0>		""`)
 	})
 
 	t.Run("trace", func(t *testing.T) {
@@ -77,7 +77,7 @@ func TestEntry(t *testing.T) {
 				SpanID:  trace.SpanID{0, 1, 2, 3, 4, 5, 6, 7},
 				TraceID: trace.TraceID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
 			},
-		}, `0001-01-01 00:00:00.000 [ERROR]	<.:0>		""	{"trace": "000102030405060708090a0b0c0d0e0f", "span": "0001020304050607"}`)
+		}, `Jan  1 00:00:00.000 [ERROR]	<.:0>		""	{"trace": "000102030405060708090a0b0c0d0e0f", "span": "0001020304050607"}`)
 	})
 
 	t.Run("color", func(t *testing.T) {
@@ -89,6 +89,6 @@ func TestEntry(t *testing.T) {
 				slog.F("hey", "hi"),
 			),
 		})
-		assert.Equal(t, "entry", "\x1b[0m\x1b[0m0001-01-01 00:00:00.000 \x1b[91m[CRITICAL]\x1b[0m\t\x1b[36m<.:0>	\x1b[0m\t\"\"\t{\x1b[34m\"hey\"\x1b[0m: \x1b[32m\"hi\"\x1b[0m}", act)
+		assert.Equal(t, "entry", "\x1b[0m\x1b[0mJan  1 00:00:00.000 \x1b[91m[CRITICAL]\x1b[0m\t\x1b[36m<.:0>	\x1b[0m\t\"\"\t{\x1b[34m\"hey\"\x1b[0m: \x1b[32m\"hi\"\x1b[0m}", act)
 	})
 }


### PR DESCRIPTION
Showing day, year, and month feels excessive for human output.

If logs are being ingested years at a time, the system consuming
should be responsible for tracking the year.