### PR TITLE
fix: synchronize test logs to prevent `t.Log` race condition

### DIFF
--- a/sloggers/slogtest/t.go
+++ b/sloggers/slogtest/t.go
@@ -69,7 +69,7 @@ func (ts *testSink) LogEntry(ctx context.Context, ent slog.SinkEntry) {
 	defer ts.mu.RUnlock()
 
 	// Don't log after the test this sink was created in has finished.
-	if ts.testDone == true {
+	if ts.testDone {
 		return
 	}
 

--- a/sloggers/slogtest/t_test.go
+++ b/sloggers/slogtest/t_test.go
@@ -45,13 +45,25 @@ func TestIgnoreErrors(t *testing.T) {
 	l.Fatal(bg, "hello")
 }
 
+func TestSkipCleanup(t *testing.T) {
+	t.Parallel()
+
+	tb := &fakeTB{}
+	slogtest.Make(tb, &slogtest.Options{
+		SkipCleanup: true,
+	})
+
+	assert.Equal(t, "cleanups", 0, tb.cleanups)
+}
+
 var bg = context.Background()
 
 type fakeTB struct {
 	testing.TB
 
-	errors int
-	fatals int
+	errors   int
+	fatals   int
+	cleanups int
 }
 
 func (tb *fakeTB) Helper() {}
@@ -67,4 +79,6 @@ func (tb *fakeTB) Fatal(v ...interface{}) {
 	panic("")
 }
 
-func (tb *fakeTB) Cleanup(fn func()) {}
+func (tb *fakeTB) Cleanup(fn func()) {
+	tb.cleanups++
+}

--- a/sloggers/slogtest/t_test.go
+++ b/sloggers/slogtest/t_test.go
@@ -66,3 +66,5 @@ func (tb *fakeTB) Fatal(v ...interface{}) {
 	tb.fatals++
 	panic("")
 }
+
+func (tb *fakeTB) Cleanup(fn func()) {}


### PR DESCRIPTION
If `(*testing.T).Log` is called concurrently of a test exiting, it's
picked up by the race detector. This adds logic to allow slogtest to
detect when a test has exited, and ensure it doesn't call
`(*testing.T).Log` after that happens.