### PR TITLE
entryhuman: Use presence of TERM to force colors

### DIFF
--- a/internal/entryhuman/entry.go
+++ b/internal/entryhuman/entry.go
@@ -170,7 +170,7 @@ func isTTY(w io.Writer) bool {
 }
 
 func shouldColor(w io.Writer) bool {
-	return isTTY(w) || os.Getenv("FORCE_COLOR") != ""
+	return isTTY(w) || os.Getenv("TERM") != ""
 }
 
 // quotes quotes a string so that it is suitable


### PR DESCRIPTION
We don't need to invent our own variable to indicate that we should log with colors despite not being connected to a TTY. Can reuse $TERM.

Now if you use slog in CI, you'll want to ensure you also set TERM=xterm-256color before you invoke any program that uses slog.