### PR TITLE
Calm down sublogger style

### DIFF
--- a/internal/entryhuman/entry.go
+++ b/internal/entryhuman/entry.go
@@ -38,8 +38,7 @@ const TimeFormat = "2006-01-02 15:04:05.000"
 var (
 	renderer = lipgloss.NewRenderer(os.Stdout, termenv.WithUnsafe())
 
-	loggerNameStyle = renderer.NewStyle().Foreground(lipgloss.Color("#A47DFF"))
-	timeStyle       = renderer.NewStyle().Foreground(lipgloss.Color("#606366"))
+	timeStyle = renderer.NewStyle().Foreground(lipgloss.Color("#606366"))
 )
 
 func render(w io.Writer, st lipgloss.Style, s string) string {
@@ -108,9 +107,8 @@ func Fmt(
 	buf.WriteString("  ")
 
 	if len(ent.LoggerNames) > 0 {
-		loggerName := "(" + quoteKey(strings.Join(ent.LoggerNames, ".")) + ")"
-		buf.WriteString(render(termW, loggerNameStyle, loggerName))
-		buf.WriteString(tab)
+		loggerName := quoteKey(strings.Join(ent.LoggerNames, ".")) + ": "
+		buf.WriteString(loggerName)
 	}
 
 	var multilineKey string

--- a/internal/entryhuman/entry_test.go
+++ b/internal/entryhuman/entry_test.go
@@ -64,7 +64,11 @@ func TestEntry(t *testing.T) {
 			"named",
 			slog.SinkEntry{
 				Level:       slog.LevelWarn,
-				LoggerNames: []string{"named", "meow"},
+				LoggerNames: []string{"some", "cat"},
+				Message:     "meow",
+				Fields: slog.M(
+					slog.F("breath", "stinky"),
+				),
 			},
 		},
 		{

--- a/internal/entryhuman/testdata/named.golden
+++ b/internal/entryhuman/testdata/named.golden
@@ -1,1 +1,1 @@
-0001-01-01 00:00:00.000 [warn]  (named.meow)  
+0001-01-01 00:00:00.000 [warn]  some.cat: meow  breath=stinky

--- a/s_test.go
+++ b/s_test.go
@@ -23,5 +23,5 @@ func TestStdlib(t *testing.T) {
 	et, rest, err := entryhuman.StripTimestamp(b.String())
 	assert.Success(t, "strip timestamp", err)
 	assert.False(t, "timestamp", et.IsZero())
-	assert.Equal(t, "entry", " [info]  (stdlib)  stdlib  hi=we\n", rest)
+	assert.Equal(t, "entry", " [info]  stdlib: stdlib  hi=we\n", rest)
 }

--- a/sloggers/slogtest/t.go
+++ b/sloggers/slogtest/t.go
@@ -74,9 +74,11 @@ func (ts *testSink) LogEntry(ctx context.Context, ent slog.SinkEntry) {
 		return
 	}
 
-	var s strings.Builder
+	var sb strings.Builder
 	// The testing package logs to stdout and not stderr.
-	entryhuman.Fmt(&s, os.Stdout, ent)
+	entryhuman.Fmt(&sb, os.Stdout, ent)
+
+	s := sb.String()
 
 	switch ent.Level {
 	case slog.LevelDebug, slog.LevelInfo, slog.LevelWarn:


### PR DESCRIPTION
The sublogger shouldn't stand out so much in the log line.

---

new:

<img width="1379" alt="Screenshot 2023-05-09 at 12 36 03 PM" src="https://github.com/coder/slog/assets/7416144/534338eb-00d4-41d4-bf4d-debbfd3c2564">

old:

<img width="1523" alt="Screenshot 2023-05-09 at 12 28 44 PM" src="https://github.com/coder/slog/assets/7416144/c37fe772-5668-4aec-91c8-8cc12cdc9d1d">
