### PR TITLE
Revert "Revert "fix: Use SyscallConn for isTTY which is safe during f…

### DIFF
--- a/internal/entryhuman/entry.go
+++ b/internal/entryhuman/entry.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 	"unicode"
 
@@ -224,9 +225,25 @@ func isTTY(w io.Writer) bool {
 	if w == forceColorWriter {
 		return true
 	}
-	f, ok := w.(interface {
-		Fd() uintptr
-	})
+	// SyscallConn is safe during file close.
+	if sc, ok := w.(interface {
+		SyscallConn() (syscall.RawConn, error)
+	}); ok {
+		conn, err := sc.SyscallConn()
+		if err != nil {
+			return false
+		}
+		var isTerm bool
+		err = conn.Control(func(fd uintptr) {
+			isTerm = term.IsTerminal(int(fd))
+		})
+		if err != nil {
+			return false
+		}
+		return isTerm
+	}
+	// Fallback to unsafe Fd.
+	f, ok := w.(interface{ Fd() uintptr })
 	return ok && term.IsTerminal(int(f.Fd()))
 }
 


### PR DESCRIPTION
This reverts commit 5275fa74f12c1a1f3604b7cb35adc8269f1c9d92.

Closes https://github.com/coder/slog/issues/176