### PR TITLE
feat: add more prominent failure notice on slogtest error

### DIFF
--- a/sloggers/slogtest/t.go
+++ b/sloggers/slogtest/t.go
@@ -82,8 +82,8 @@ func (ts *testSink) LogEntry(ctx context.Context, ent slog.SinkEntry) {
 	switch ent.Level {
 	case slog.LevelDebug, slog.LevelInfo, slog.LevelWarn:
 		ts.tb.Log(sb.String())
-	case slog.LevelError, slog.LevelCritical, slog.LevelFatal:
-		if ts.opts.IgnoreErrors && ent.Level != slog.LevelFatal {
+	case slog.LevelError, slog.LevelCritical:
+		if ts.opts.IgnoreErrors {
 			ts.tb.Log(sb.String())
 		} else {
 			sb.WriteString(fmt.Sprintf(
@@ -92,6 +92,9 @@ func (ts *testSink) LogEntry(ctx context.Context, ent slog.SinkEntry) {
 			))
 			ts.tb.Error(sb.String())
 		}
+	case slog.LevelFatal:
+		sb.WriteString("\n *** slogtest: FATAL log detected; TEST FAILURE ***")
+		ts.tb.Fatal(sb.String())
 	}
 }
 

--- a/sloggers/slogtest/t_test.go
+++ b/sloggers/slogtest/t_test.go
@@ -55,7 +55,7 @@ func TestCleanup(t *testing.T) {
 		fn()
 	}
 
-	// This shoud not log since the logger was cleaned up.
+	// This should not log since the logger was cleaned up.
 	l.Info(bg, "hello")
 	assert.Equal(t, "no logs", 0, tb.logs)
 }


### PR DESCRIPTION
When looking at test failures on coder/coder it's just not that easy to tell that a failure is due to a dropped error log.  The error log gets dropped, the test proceeds, all the `require` and `assert` calls pass, but it's marked a failure.  The log itself is not very visually distinct with `[erro]` instead of like `[info]` being the only distinguishing mark.

If you didn't know that `slogtest` by default fails tests for logging errors, then you'd probably be hard pressed to understand why the test failed.

This is an attempt to make it more prominent and easy to understand.

~Also, for fatal logs, we no longer call `tb.Fatal()`, which is only allowed in the main test goroutine, and loggers are routinely passed to goroutines.~ EDIT: reverted this change, since logger.Fatal() calls os.Exit() which can't really be tested.  If we hit a `Fatal` log in the product code, not the test, all bets are probably off anyway...