### PR TITLE
fix: add additional severity field to stackdriver

### DIFF
--- a/sloggers/slogstackdriver/slogstackdriver.go
+++ b/sloggers/slogstackdriver/slogstackdriver.go
@@ -56,6 +56,7 @@ func (s stackdriverSink) LogEntry(ctx context.Context, ent slog.SinkEntry) {
 	// https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/configuration#special-fields
 	e := slog.M(
 		slog.F("logging.googleapis.com/severity", sev(ent.Level)),
+		slog.F("severity", sev(ent.Level)),
 		slog.F("message", ent.Message),
 		// Unfortunately, both of these fields are required.
 		slog.F("timestampSeconds", ent.Time.Unix()),

--- a/sloggers/slogstackdriver/slogstackdriver_test.go
+++ b/sloggers/slogstackdriver/slogstackdriver_test.go
@@ -43,7 +43,7 @@ func TestStackdriver(t *testing.T) {
 
 	j := entryjson.Filter(b.String(), "timestampSeconds")
 	j = entryjson.Filter(j, "timestampNanos")
-	exp := fmt.Sprintf(`{"logging.googleapis.com/severity":"ERROR","message":"line1\n\nline2","logging.googleapis.com/sourceLocation":{"file":"%v","line":40,"function":"cdr.dev/slog/sloggers/slogstackdriver_test.TestStackdriver"},"logging.googleapis.com/operation":{"producer":"meow"},"logging.googleapis.com/trace":"projects/%v/traces/%v","logging.googleapis.com/spanId":"%v","logging.googleapis.com/trace_sampled":%v,"wowow":"me\nyou"}
+	exp := fmt.Sprintf(`{"logging.googleapis.com/severity":"ERROR","severity":"ERROR","message":"line1\n\nline2","logging.googleapis.com/sourceLocation":{"file":"%v","line":40,"function":"cdr.dev/slog/sloggers/slogstackdriver_test.TestStackdriver"},"logging.googleapis.com/operation":{"producer":"meow"},"logging.googleapis.com/trace":"projects/%v/traces/%v","logging.googleapis.com/spanId":"%v","logging.googleapis.com/trace_sampled":%v,"wowow":"me\nyou"}
 `, slogstackdriverTestFile, projectID, span.SpanContext().TraceID(), span.SpanContext().SpanID(), span.SpanContext().IsSampled())
 	assert.Equal(t, "entry", exp, j)
 }


### PR DESCRIPTION
The `logging.googleapis.com/severity` field is no longer mentioned in https://cloud.google.com/logging/docs/agent/configuration#special-fields docs, and when viewed in Google Cloud Logging, severity is missing (and inferred from stderr as ERROR).

For this reason, we add the `severity` field as well. The `logging.googleapis.com/severity` field is still mentioned in https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/configuration#special-fields, which is why we keep it.

An example configuration on that page suggests rewriting the field (https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/configuration#example_configuration_2), however, this seemed cumbersome to do in our deployment on `big.cdr.dev` and sending both fields seems like a good compromise.