### PR TITLE
feat: ignore context.Canceled by default in slogtest

### DIFF
--- a/sloggers/slogtest/t.go
+++ b/sloggers/slogtest/t.go
@@ -38,7 +38,7 @@ type Options struct {
 	// conditions exist when t.Log is called concurrently of a test exiting. Set
 	// to true if you don't need this behavior.
 	SkipCleanup bool
-	// IgnoredErrorValues causes the test logger not to error the test on Error
+	// IgnoredErrorIs causes the test logger not to error the test on Error
 	// if the SinkEntry contains one of the listed errors in its "error" Field.
 	// Errors are matched using xerrors.Is().
 	//
@@ -48,16 +48,15 @@ type Options struct {
 	IgnoredErrorIs []error
 }
 
-// Make creates a Logger that writes logs to tb in a human readable format.
+var DefaultIgnoredErrorIs = []error{context.Canceled, context.DeadlineExceeded}
+
+// Make creates a Logger that writes logs to tb in a human-readable format.
 func Make(tb testing.TB, opts *Options) slog.Logger {
 	if opts == nil {
 		opts = &Options{}
 	}
 	if opts.IgnoredErrorIs == nil {
-		opts.IgnoredErrorIs = []error{
-			context.Canceled,
-			context.DeadlineExceeded,
-		}
+		opts.IgnoredErrorIs = DefaultIgnoredErrorIs
 	}
 
 	sink := &testSink{
@@ -82,7 +81,7 @@ type testSink struct {
 	testDone bool
 }
 
-func (ts *testSink) LogEntry(ctx context.Context, ent slog.SinkEntry) {
+func (ts *testSink) LogEntry(_ context.Context, ent slog.SinkEntry) {
 	ts.mu.RLock()
 	defer ts.mu.RUnlock()
 


### PR DESCRIPTION
I feel like we spend a lot of time chasing flakes due to logging `context.Canceled` at `Error` in product code, because a lot of our tests shut down by canceling contexts.  This is not a good use of our time, so we should, by default, ignore these errors vis a vis erroring the test case in `slogtest`