### PR TITLE
fix(internal/syncwriter): stop corrupting test output on sink write errors

### DIFF
--- a/internal/syncwriter/syncwriter.go
+++ b/internal/syncwriter/syncwriter.go
@@ -24,7 +24,9 @@ func New(w io.Writer) *Writer {
 		w: w,
 
 		errorf: func(f string, v ...interface{}) {
-			println(fmt.Sprintf(f, v...))
+			// Avoid the builtin println, which writes to fd 2
+			// unsynchronized and can corrupt concurrent go test output.
+			fmt.Fprintf(os.Stderr, f+"\n", v...)
 		},
 	}
 }

--- a/internal/syncwriter/syncwriter_test.go
+++ b/internal/syncwriter/syncwriter_test.go
@@ -3,6 +3,7 @@ package syncwriter
 import (
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"cdr.dev/slog/v3/internal/assert"
@@ -72,6 +73,34 @@ func TestWriter_Sync(t *testing.T) {
 		})
 		sw.Write("hello", nil)
 	})
+}
+
+// The default handler must report through the os.Stderr variable, not the
+// builtin println that bypasses it. Reverting to println fails this test.
+//
+// Not parallel: it swaps the process-wide os.Stderr.
+func TestWriter_defaultErrorReportsThroughStderr(t *testing.T) {
+	r, w, err := os.Pipe()
+	assert.Success(t, "pipe", err)
+
+	tw := New(syncWriter{
+		wf: func([]byte) (int, error) { return 0, io.EOF },
+		sf: func() error { return nil },
+	})
+
+	orig := os.Stderr
+	os.Stderr = w
+	tw.Write("sinkname", []byte("entry"))
+	os.Stderr = orig
+	assert.Success(t, "close", w.Close())
+
+	out, err := io.ReadAll(r)
+	assert.Success(t, "read", err)
+
+	got := string(out)
+	assert.True(t, "reported via stderr", strings.Contains(got, "sinkname: failed to write entry"))
+	assert.True(t, "single trailing newline", strings.HasSuffix(got, "\n"))
+	assert.Equal(t, "newline count", 1, strings.Count(got, "\n"))
 }
 
 func Test_errorsIsAny(t *testing.T) {


### PR DESCRIPTION
## The problem

`internal/syncwriter` reported sink write and sync failures with the builtin `println`. That call writes raw bytes to fd 2, and it emits the message and its trailing newline as two separate, unsynchronized syscalls. Under concurrency, a test framework's `--- PASS:` line can land between those two writes, so `test2json` never records the terminal action and tools like `gotestsum` flag an innocent, passing test as failed or unknown. We hit this in `coder/coder`, where a passing `TestRetryWithInterval` was reported as a failure.

Fixes #225.

## The fix

Replace `println` with one `fmt.Fprintf(os.Stderr, ...)`. The write can't be split across syscalls, so a reported error can no longer wedge into another test's result line, which keeps the result marker at the start of a line.

This is the minimal change. Suppressing the benign "reader gone" errors that triggered the original flake is being handled on the `coder/coder` side instead (a writer that opts out of those errors), so slog does not hide the fact that a user-assigned sink failed to receive output.

## Evidence from a real CI failure

From [this `coder/coder` run](https://github.com/coder/coder/actions/runs/26586696037/job/78334548165) (2026-05-28, commit `094fe97`). `gotestsum` marked a passing `TestRetryWithInterval` and all its subtests `(unknown)`:

```
=== FAIL: cli TestRetryWithInterval (unknown)
```

because a concurrent `port-forward -v` test's teardown logged a closed-pipe error through the old `println`, which split the line:

```
sloghuman: failed to write entry: io: read/write on closed pipe--- PASS: TestRetryWithInterval (0.00s)
```

The `--- PASS:` marker is no longer at the start of a line, so `test2json` dropped the terminal action. This change keeps the newline attached so the marker always starts a line.

## Tests

- `TestWriter_defaultErrorReportsThroughStderr`: the default handler reports through the `os.Stderr` variable in one newline-terminated write, and fails if reverted to `println`.

`go vet ./...`, `gofmt`/`gofumpt`, and `go test -race ./internal/syncwriter/` are clean, and the full module suite passes.

## Picking this up in coder/coder

`coder/coder` pins `cdr.dev/slog/v3 v3.0.0` with no `replace`, so it won't update on its own. Once this merges and a tag like `v3.0.1` is cut, a follow-up PR there bumps the dependency with `go get cdr.dev/slog/v3@v3.0.1 && go mod tidy`.

<details>
<summary>Investigation and decision log</summary>

**Root cause** (`internal/syncwriter/syncwriter.go` on `main`): the `New` error handler ran `println(fmt.Sprintf(...))`. `println` writes to fd 2 out of sync with the test stream and splits the text and newline across two syscalls, which is what lets the interleave drop `test2json` terminal actions.

**Scope:** an earlier revision also suppressed benign `io.ErrClosedPipe`/`syscall.EPIPE` write errors inside slog. Per maintainer feedback, that was dropped: if a user-assigned sink returns an error, slog should not hide it. The opt-out belongs in the consumer (`coder/coder`), which is where the closing writer lives.

**Test scope:** reproducing the interleave itself is inherently racy, so the test asserts a deterministic, revert-sensitive property instead: diagnostics flow through the redirectable `os.Stderr` variable rather than the raw `println` builtin.

</details>

---

_Generated by Coder Agents on behalf of @EhabY._